### PR TITLE
Remove bash completion from build matrix configuration

### DIFF
--- a/generate.xml
+++ b/generate.xml
@@ -1187,7 +1187,6 @@
         <option value="--disable-shared" />
         <option value="--build-dir=my-build" />
         <option value="--prefix=$TRAVIS_BUILD_DIR/my-prefix" />
-        <option value="--with-bash-completiondir" />
         <option value="CFLAGS='-Og -g --coverage'" />
         <option value="CXXFLAGS='-Og -g --coverage'" />
       </job>
@@ -1218,7 +1217,6 @@
         <option value="--build-qrencode" />
         <option value="--build-boost" />
         <option value="--disable-static" />
-        <option value="--with-bash-completiondir" />
         <option value="--prefix=$TRAVIS_BUILD_DIR/my-prefix" />
         <option value="CFLAGS='-Og -g'" />
         <option value="CXXFLAGS='-Og -g'" />


### PR DESCRIPTION
Remove bash completion from build matrix configuration since it requires sudo and travis-ci fails on this due to permissions