### PR TITLE
Update flags, hide warnings from dependencies

### DIFF
--- a/generate.xml
+++ b/generate.xml
@@ -112,19 +112,24 @@
 
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
-      <!-- boost -->
-      <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" />
-
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
-      <flag name="Wno-long-long" comment="Allow use of C99 'long long' type." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
+      <flag name="Wno-long-long" comment="Allow use of C99 'long long' type." context="c" />
+      <flag name="Wno-comment" comment="Allow for multi-line commenting." context="c++" />
+      <flag name="Wno-type-limits" comment="Disallow warning always true conditions related to types (allows generalization related to constants)." context="c++" />
+
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
       <flag name="fno-var-tracking-assignments" compiler="gcc" comment="Limit delays and warnings." context="c++" />
 
@@ -341,18 +346,23 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <!-- boost -->
-      <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" />
-      <flag name="Wno-redeclared-class-member" compiler="clang" comment="Clean up boost 1.55 headers." context="c++" />
+      <!-- <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" /> -->
+      <!-- <flag name="Wno-redeclared-class-member" compiler="clang" comment="Clean up boost 1.55 headers." context="c++" /> -->
 
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 
@@ -513,17 +523,22 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <!-- boost -->
-      <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" />
+      <!-- <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" /> -->
 
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 
@@ -730,15 +745,20 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <!-- boost -->
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 
@@ -905,18 +925,23 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <!-- boost -->
-      <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" />
-      <flag name="Wno-redeclared-class-member" compiler="clang" comment="Clean up boost 1.55 headers." context="c++" />
+      <!-- <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" /> -->
+      <!-- <flag name="Wno-redeclared-class-member" compiler="clang" comment="Clean up boost 1.55 headers." context="c++" /> -->
 
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 
@@ -1067,20 +1092,25 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <!-- boost -->
-      <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" />
+      <!-- <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" /> -->
 
       <!-- bx -->
       <flag name="Wno-unused-parameter" comment="Clean up bx generated code." context="c++" />
 
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 
@@ -1317,14 +1347,19 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 
@@ -1475,18 +1510,23 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <!-- boost -->
-      <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" />
-      <flag name="Wno-redeclared-class-member" compiler="clang" comment="Clean up boost 1.55 headers." context="c++" />
+      <!-- <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" /> -->
+      <!-- <flag name="Wno-redeclared-class-member" compiler="clang" comment="Clean up boost 1.55 headers." context="c++" /> -->
 
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 
@@ -1675,17 +1715,22 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <!-- boost -->
-      <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" />
+      <!-- <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" /> -->
 
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 
@@ -1843,18 +1888,23 @@
       <flag name="std=c++11" comment="Require c++11 for all c++ products." context="c++" />
 
       <flag name="Wall" comment="Warn on all stuff." context="c" />
+      <flag name="Wall" comment="Warn on all stuff." context="c++" />
       <flag name="Wextra" comment="Warn on extra stuff." context="c" />
+      <flag name="Wextra" comment="Warn on extra stuff." context="c++" />
       <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c" />
+      <flag name="Wpedantic" alternate="pedantic" comment="Be really annoying." context="c++" />
+      <flag name="Wno-reorder" comment="Disallow warning on style order of declarations." context="c++" />
+      <flag name="Wno-missing-field-initializers" comment="Suppress warning for incomplete field initialization." context="c++" />
       <flag name="Wno-missing-braces" comment="Conform to style." context="c++" />
       <flag name="Wno-mismatched-tags" compiler="clang" comment="Conflict in stdlib under clang." context="c++" />
 
       <!-- boost -->
-      <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" />
-      <flag name="Wno-redeclared-class-member" compiler="clang" comment="Clean up boost 1.55 headers." context="c++" />
+      <!-- <flag name="Wno-deprecated-declarations" compiler="gcc" comment="Clean up boost 1.55 headers." context="c++" /> -->
+      <!-- <flag name="Wno-redeclared-class-member" compiler="clang" comment="Clean up boost 1.55 headers." context="c++" /> -->
 
       <flag name="fstack-protector" comment="Protect stack." context="link" />
       <flag name="fstack-protector-all" comment="Protect stack comprehensively." context="link" />
-      <flag name="fvisibility-hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" />
+      <!-- <flag name="fvisibility=hidden" compiler="gcc" comment="Hide internal functions from external libs." context="c++" /> -->
       <flag name="fvisibility-inlines-hidden" compiler="gcc" comment="Hide inlines from external libs." context="c++" />
     </configure>
 

--- a/templates/gsl.Makefile.am
+++ b/templates/gsl.Makefile.am
@@ -345,7 +345,7 @@ function define_cpp_lib_variables(variables, library, make, configure, repositor
             my.variables.libs += " ${$(my.cname)_LIBS}"
         endif
         if (my.is_boost | my.is_common | my.is_language | my.is_package)
-            my.variables.cpp_flags += " ${$(my.cname)_CPPFLAGS}"
+            my.variables.cpp_flags += " ${$(my.cname)_SYS_CPPFLAGS}"
         endif
         if (0)
             my.variables.ccc_flags += " ${$(my.cname)_CFLAGS}"

--- a/templates/gsl.configure.ac
+++ b/templates/gsl.configure.ac
@@ -10,6 +10,10 @@
 # Functions
 ###############################################################################
 
+function substitute_system_include(variable_name)
+    return "`echo ${$(my.variable_name)} | $SED s/^-I/-isystem/g | $SED s/' -I'/' -isystem'/g`"
+endfunction
+
 function format_template_files(configure)
     define my.configure = format_template_files.configure
     define my.template_files = ""
@@ -217,6 +221,9 @@ AC_PROG_CXX
 
 # Enable shared libraries if available, and static if they don't conflict.
 AC_PROG_LIBTOOL
+
+# Enable sed for substitution.
+AC_PROG_SED
 
 # Compute the canonical host-system type variable host, including host_os.
 AC_CANONICAL_HOST
@@ -447,6 +454,7 @@ AS_CASE([${$(my.symbol)}], [yes],
 .   if (is_empty(my.symbol))
 AM_ICONV
 AC_SUBST([iconv_CPPFLAGS], [${INCICONV}])
+AC_SUBST([iconv_SYS_CPPFLAGS], [$(substitute_system_include("INCICONV"))])
 AC_SUBST([iconv_LIBS], [${LIBICONV}])
 AC_MSG_NOTICE([$(my.cname)_CPPFLAGS : ${$(my.cname)_CPPFLAGS}])
 AC_MSG_NOTICE([$(my.cname)_LIBS : ${$(my.cname)_LIBS}])
@@ -454,6 +462,7 @@ AC_MSG_NOTICE([$(my.cname)_LIBS : ${$(my.cname)_LIBS}])
 AS_CASE([${$(my.symbol)}], [yes],
     AM_ICONV
     AC_SUBST([iconv_CPPFLAGS], [${INCICONV}])
+    AC_SUBST([iconv_SYS_CPPFLAGS], [$(substitute_system_include("INCICONV"))])
     AC_SUBST([iconv_LIBS], [${LIBICONV}])
     AC_MSG_NOTICE([$(my.cname)_CPPFLAGS : ${$(my.cname)_CPPFLAGS}])
     AC_MSG_NOTICE([$(my.cname)_LIBS : ${$(my.cname)_LIBS}]))
@@ -481,6 +490,7 @@ AS_CASE([${$(my.symbol)}], [yes],
 .
 $(my.indent_prefix)$(my.prefix_bracket)AX_$(my.uname)(
     $(my.indent_prefix)[AC_SUBST([$(my.cname)_CPPFLAGS], [${$(my.uname)_CPPFLAGS}])
+     $(my.indent_prefix)AC_SUBST([$(my.cname)_SYS_CPPFLAGS], [$(substitute_system_include("$(my.uname)_CPPFLAGS"))])
 .   if (my.cname = "pthread")
      $(my.indent_prefix)AC_SUBST([$(my.cname)_LIBS], [-lpthread])
 .   else
@@ -735,6 +745,7 @@ AC_MSG_NOTICE([$(my.cname)_LIBS : ${$(my.cname)_LIBS}])
 AS_CASE([${CC}], [$(my.compiler_pattern)],
     [AX_BOOST_BASE([$(my.version)],
         [AC_SUBST([boost_CPPFLAGS], [${BOOST_CPPFLAGS}])
+         AC_SUBST([boost_SYS_CPPFLAGS], [$(substitute_system_include("BOOST_CPPFLAGS"))])
          AC_SUBST([boost_LDFLAGS], [${BOOST_LDFLAGS}])
          AC_MSG_NOTICE([boost_CPPFLAGS : ${boost_CPPFLAGS}])
          AC_MSG_NOTICE([boost_LDFLAGS : ${boost_LDFLAGS}])],
@@ -796,6 +807,7 @@ AS_CASE([${$(my.symbol)}], [yes],
 PKG_CHECK_MODULES([$(my.cname)], [$(my.check)])
 AC_SUBST([$(my.cname)_PKG], ['$(my.check)'])
 AC_SUBST([$(my.cname)_CPPFLAGS], [${$(my.cname)_CFLAGS}])
+AC_SUBST([$(my.cname)_SYS_CPPFLAGS], [$(substitute_system_include("$(my.cname)_CFLAGS"))])
 AC_MSG_NOTICE([$(my.cname)_CPPFLAGS : ${$(my.cname)_CPPFLAGS}])
 AC_MSG_NOTICE([$(my.cname)_LIBS : ${$(my.cname)_LIBS}])
 .   elsif (is_empty(my.dependency.extract))
@@ -803,6 +815,7 @@ AS_CASE([${$(my.symbol)}], [yes],
     [PKG_CHECK_MODULES([$(my.cname)], [$(my.check)])
      AC_SUBST([$(my.cname)_PKG], ['$(my.check)'])
      AC_SUBST([$(my.cname)_CPPFLAGS], [${$(my.cname)_CFLAGS}])
+     AC_SUBST([$(my.cname)_SYS_CPPFLAGS], [$(substitute_system_include("$(my.cname)_CFLAGS"))])
      AC_MSG_NOTICE([$(my.cname)_CPPFLAGS : ${$(my.cname)_CPPFLAGS}])
      AC_MSG_NOTICE([$(my.cname)_LIBS : ${$(my.cname)_LIBS}])],
     [AC_SUBST([$(my.cname)_PKG], [])])
@@ -813,6 +826,7 @@ AS_CASE([${$(my.symbol)}], [yes],
         [$(my.symbol)="$(my.default)"])
      AC_SUBST([$(my.cname)_PKG], ['$(my.check)'])
      AC_SUBST([$(my.cname)_CPPFLAGS], [${$(my.cname)_CFLAGS}])
+     AC_SUBST([$(my.cname)_SYS_CPPFLAGS], [$(substitute_system_include("$(my.cname)_CFLAGS"))])
      AC_MSG_NOTICE([$(my.cname)_CPPFLAGS : ${$(my.cname)_CPPFLAGS}])
      AC_MSG_NOTICE([$(my.cname)_LIBS : ${$(my.cname)_LIBS}])],
     [AC_SUBST([$(my.cname)_PKG], [])])


### PR DESCRIPTION
Add -Wall -Wpedantic -Wextra, -Wno-reorder, -Wno-missing-initializers.  Correct -fvisibility-hidden to -fvisibility=hidden and disable (enabling requires proper annotation of functions).  Disable warnings from include directories provided by dependencies.