### PR TITLE
Two consecutive hyphens removed from comments.

### DIFF
--- a/generate.xml
+++ b/generate.xml
@@ -198,7 +198,7 @@
 
     <install>
       <build name="icu" version="55.1" parallel="true" >
-        <!-- Bug in ICU build requires --enable-draft. -->
+        <!-- Bug in ICU build requires enable-draft. -->
         <option value="--enable-draft" />
         <option value="--enable-tools" />
         <option value="--disable-extras" />
@@ -235,7 +235,8 @@
       <build name="bitcoin" github="libbitcoin" repository="libbitcoin" branch="master" parallel="true" >
         <option value="${with_boost}" />
         <option value="${with_pkgconfigdir}" />
-        <!--<option value="--disable-silent-rules" />-->
+        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
+        <!--<option value="XXdisable-silent-rules" />-->
       </build>
     </install>
 
@@ -833,14 +834,16 @@
     <matrix>
       <job system="osx" compiler="clang" link="static" >
         <!-- <get name="swig" /> -->
-        <!-- <option value="--with-java" /> -->
+        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
+        <!-- <option value="XXwith-java" /> -->
         <option value="--disable-shared" />
         <option value="--build-boost" />
         <option value="--prefix=$TRAVIS_BUILD_DIR/my-prefix" />
       </job>
       <job system="linux" compiler="clang" link="static" version="3.4" >
         <!-- <get name="swig" /> -->
-        <!-- <option value="--with-python" /> -->
+        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
+        <!-- <option value="XXwith-python" /> -->
         <option value="--disable-shared" />
         <option value="--build-boost" />
         <option value="--prefix=$TRAVIS_BUILD_DIR/my-prefix" />
@@ -850,7 +853,8 @@
       <job system="linux" compiler="gcc" link="static" coverage="true" >
         <exclude path="clone/*" />
         <!-- <get name="swig" /> -->
-        <!-- <option value="--with-java" /> -->
+        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
+        <!-- <option value="XXwith-java" /> -->
         <option value="--disable-shared" />
         <option value="--build-boost" />
         <option value="--build-dir=my-build" />
@@ -862,7 +866,8 @@
         <get name="boost" />
         <!-- <get name="swig" /> -->
         <option value="--disable-static" />
-        <!-- <option value="--with-python" /> -->
+        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
+        <!-- <option value="XXwith-python" /> -->
       </job>
       <job system="linux" compiler="clang" link="dynamic" sudo="false" >
         <!-- This version isn't available in the repository. -->
@@ -876,8 +881,9 @@
       </job>
       <job system="linux" compiler="gcc" link="dynamic" version="4.8" sudo="false" >
         <!-- <get name="swig" /> -->
-        <!-- <option value="--with-java" /> -->
-        <!-- <option value="--with-python" /> -->
+        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
+        <!-- <option value="XXwith-java" /> -->
+        <!-- <option value="XXwith-python" /> -->
         <option value="--disable-static" />
         <option value="--build-boost" />
         <option value="--prefix=$TRAVIS_BUILD_DIR/my-prefix" />
@@ -1163,7 +1169,7 @@
 
     <install>
       <build name="icu" version="55.1" parallel="true" >
-        <!-- Bug in ICU build requires --enable-draft. -->
+        <!-- Bug in ICU build requires enable-draft. -->
         <option value="--enable-draft" />
         <option value="--enable-tools" />
         <option value="--disable-extras" />

--- a/generate.xml
+++ b/generate.xml
@@ -235,8 +235,6 @@
       <build name="bitcoin" github="libbitcoin" repository="libbitcoin" branch="master" parallel="true" >
         <option value="${with_boost}" />
         <option value="${with_pkgconfigdir}" />
-        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
-        <!--<option value="XXdisable-silent-rules" />-->
       </build>
     </install>
 
@@ -834,16 +832,12 @@
     <matrix>
       <job system="osx" compiler="clang" link="static" >
         <!-- <get name="swig" /> -->
-        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
-        <!-- <option value="XXwith-java" /> -->
         <option value="--disable-shared" />
         <option value="--build-boost" />
         <option value="--prefix=$TRAVIS_BUILD_DIR/my-prefix" />
       </job>
       <job system="linux" compiler="clang" link="static" version="3.4" >
         <!-- <get name="swig" /> -->
-        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
-        <!-- <option value="XXwith-python" /> -->
         <option value="--disable-shared" />
         <option value="--build-boost" />
         <option value="--prefix=$TRAVIS_BUILD_DIR/my-prefix" />
@@ -853,8 +847,6 @@
       <job system="linux" compiler="gcc" link="static" coverage="true" >
         <exclude path="clone/*" />
         <!-- <get name="swig" /> -->
-        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
-        <!-- <option value="XXwith-java" /> -->
         <option value="--disable-shared" />
         <option value="--build-boost" />
         <option value="--build-dir=my-build" />
@@ -866,8 +858,6 @@
         <get name="boost" />
         <!-- <get name="swig" /> -->
         <option value="--disable-static" />
-        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
-        <!-- <option value="XXwith-python" /> -->
       </job>
       <job system="linux" compiler="clang" link="dynamic" sudo="false" >
         <!-- This version isn't available in the repository. -->
@@ -881,9 +871,6 @@
       </job>
       <job system="linux" compiler="gcc" link="dynamic" version="4.8" sudo="false" >
         <!-- <get name="swig" /> -->
-        <!-- Replace XX with two consecutive hyphens if not commented. Two consecutive hypens not allowed in comments -->
-        <!-- <option value="XXwith-java" /> -->
-        <!-- <option value="XXwith-python" /> -->
         <option value="--disable-static" />
         <option value="--build-boost" />
         <option value="--prefix=$TRAVIS_BUILD_DIR/my-prefix" />


### PR DESCRIPTION
Two consecutive hyphens are not allowed inside comments (see https://www.w3.org/TR/xml/#sec-comments ). The xml file was invalid and caused problems using xml-tools.

The solution with comment of comment is ugly but still better than invalid xml. The better way in my opinion is not comment code that can be used or remove commented code that nobody uses.