### PR TITLE
Renaming (error fix caused by generate.sh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ make && sudo make install
 cd ../../
 
 # Clone all libbitcoin repositories.
-git clone https://github.com/libbitcoin/libbitcoin.git
+git clone https://github.com/libbitcoin/libbitcoin-system.git
 git clone https://github.com/libbitcoin/libbitcoin-blockchain.git
 git clone https://github.com/libbitcoin/libbitcoin-build.git
 git clone https://github.com/libbitcoin/libbitcoin-client.git


### PR DESCRIPTION
"git clone https://github.com/libbitcoin/libbitcoin.git" generates a new libbitcoin folder and the libbitcoin-system folder doesn't exist (it will be created later for some reason, but the src folder will not exist). The genarate.sh script causes the following error: .../libbitcoin-system/src: No such file or directory.