### PR TITLE
Update actions/checkout.

### DIFF
--- a/templates/gsl.ci.yml
+++ b/templates/gsl.ci.yml
@@ -632,7 +632,7 @@ endfunction # get_sln_tests
 
       - name: Coveralls.io Upload
         if: ${{ matrix.coverage == 'cov' }}
-        uses: coverallsapp/github-action@master
+        uses: pmienk/coveralls-github-action@master
         with:
           path-to-lcov: "./coverage.info"
           github-token: ${{ secrets.github_token }}

--- a/templates/gsl.ci.yml
+++ b/templates/gsl.ci.yml
@@ -728,7 +728,7 @@ endfunction # get_sln_tests
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
 .   emit_step_prepare_toolchain(my.config)
 
@@ -759,7 +759,7 @@ endfunction # get_sln_tests
         uses: microsoft/setup-msbuild@v1.1
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize SDK
         shell: powershell


### PR DESCRIPTION
Removes many Node.js 12 deprecated warnings.  Remaining warnings are related to coveralls, which has not been fixed as of yet.