### PR TITLE
install scripts: add -h as alias for --help

### DIFF
--- a/docker/bs-linux-startup.sh
+++ b/docker/bs-linux-startup.sh
@@ -47,7 +47,7 @@ parse_command_line_options()
             (--unconditional-init)  INIT_UNCONDITIONAL="yes";;
 
             # Standard
-            (--help)                DISPLAY_HELP="yes";;
+            (--help|-h)             DISPLAY_HELP="yes";;
         esac
     done
 }

--- a/docker/bs-linux.sh
+++ b/docker/bs-linux.sh
@@ -46,7 +46,7 @@ parse_command_line_options()
             (--build-only)      BUILD_ONLY="yes";;
             (--init-only)       INIT_ONLY="yes";;
             # Standard
-            (--help)            DISPLAY_HELP="yes";;
+            (--help|-h)         DISPLAY_HELP="yes";;
         esac
     done
 }

--- a/docker/bx-linux.sh
+++ b/docker/bx-linux.sh
@@ -46,7 +46,7 @@ parse_command_line_options()
             (--build-only)      BUILD_ONLY="yes";;
             (--init-only)       INIT_ONLY="yes";;
             # Standard
-            (--help)            DISPLAY_HELP="yes";;
+            (--help|-h)         DISPLAY_HELP="yes";;
         esac
     done
 }

--- a/templates/shared/common_install_shell_artifacts.gsl
+++ b/templates/shared/common_install_shell_artifacts.gsl
@@ -220,7 +220,7 @@ endfunction
 # --disable-shared         Disables shared library builds.
 # --disable-static         Disables static library builds.
 # --verbose                Display verbose output (defaults to quiet on called tooling).
-# --help                   Display usage, overriding script execution.
+# --help, -h               Display usage, overriding script execution.
 #
 # Verified on Ubuntu 14.04, requires gcc-4.8 or newer.
 # Verified on OSX 10.10, using MacPorts and Homebrew repositories, requires
@@ -270,7 +270,7 @@ display_help()
     display_message "  --prefix=<absolute-path> Library install location (defaults to /usr/local)."
     display_message "  --disable-shared         Disables shared library builds."
     display_message "  --disable-static         Disables static library builds."
-    display_message "  --help                   Display usage, overriding script execution."
+    display_message "  --help, -h               Display usage, overriding script execution."
     display_message ""
     display_message "All unrecognized options provided shall be passed as configuration options for "
     display_message "all dependencies."
@@ -342,7 +342,7 @@ parse_command_line_options()
     for OPTION in "$@"; do
         case $OPTION in
             # Standard script options.
-            (--help)                DISPLAY_HELP="yes";;
+            (--help|-h)             DISPLAY_HELP="yes";;
             (--verbose)             DISPLAY_VERBOSE="yes";;
 
             # Standard build options.


### PR DESCRIPTION
All executables in Libbitcoin have --help and -h, however -h is missing at the install scripts.

Which is unexpected and it happened to me a couple times that I used -h and that the install script executed instead of displaying help.
