### PR TITLE
Re-enable working default build directory when not specified

### DIFF
--- a/templates/gsl.install-cmake.sh
+++ b/templates/gsl.install-cmake.sh
@@ -67,7 +67,7 @@ endfunction
 .macro define_build_variables_custom(repository)
 .   define my.repo = define_build_variables_custom.repository
 .   heading2("The default build directory.")
-BUILD_SRC_DIR="build-$(my.repo.name)"
+BUILD_SRC_DIR="\$(pwd)/build-$(my.repo.name)"
 
 PRESUMED_CI_PROJECT_PATH=\$(pwd)
 

--- a/templates/gsl.install-cmakepresets.sh
+++ b/templates/gsl.install-cmakepresets.sh
@@ -80,7 +80,7 @@ declare -A REPO_PRESET
 .macro define_build_variables_custom(repository)
 .   define my.repo = define_build_variables_custom.repository
 .   heading2("The default build directory.")
-BUILD_SRC_DIR="build-$(my.repo.name)"
+BUILD_SRC_DIR="\$(pwd)/build-$(my.repo.name)"
 
 PRESUMED_CI_PROJECT_PATH=\$(pwd)
 

--- a/templates/gsl.install.sh
+++ b/templates/gsl.install.sh
@@ -49,7 +49,7 @@ endfunction
 .endmacro # custom_documentation
 .
 .macro custom_configuration(repository, install)
-    display_message "BUILD_SRC_DIR          : $BUILD_SRC_DIR"
+    display_message "BUILD_SRC_DIR         : $BUILD_SRC_DIR"
 .endmacro # custom_configuration
 .
 .macro custom_script_options()
@@ -60,7 +60,7 @@ endfunction
 .macro define_build_variables_custom(repository)
 .   define my.repo = define_build_variables_custom.repository
 .   heading2("The default build directory.")
-BUILD_SRC_DIR="build-$(my.repo.name)"
+BUILD_SRC_DIR="\$(pwd)/build-$(my.repo.name)"
 
 PRESUMED_CI_PROJECT_PATH=\$(pwd)
 


### PR DESCRIPTION
Recently the `install.sh` script stopped working locally unless I added the `--build-dir` option.  This allows a (working) default to be used again.  Also fixes a spacing typo.